### PR TITLE
Fix: consider disableRelease option from pnpm plugin node.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -232,7 +232,7 @@ class ReleaseItPnpmPlugin extends Plugin {
   }
 
   async release() {
-    if (this.options?.pnpm?.disableRelease || !this.options?.github?.release) 
+    if (this.options?.disableRelease || this.options?.pnpm?.disableRelease || !this.options?.github?.release)
       return
 
     await this.step({

--- a/src/index.js
+++ b/src/index.js
@@ -232,8 +232,7 @@ class ReleaseItPnpmPlugin extends Plugin {
   }
 
   async release() {
-    if (this.options?.disableRelease)
-      return
+    if (this.options?.pnpm?.disableRelease || !this.options?.github?.release) return
 
     await this.step({
       task: async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -232,7 +232,8 @@ class ReleaseItPnpmPlugin extends Plugin {
   }
 
   async release() {
-    if (this.options?.pnpm?.disableRelease || !this.options?.github?.release) return
+    if (this.options?.pnpm?.disableRelease || !this.options?.github?.release) 
+      return
 
     await this.step({
       task: async () => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

release-it-pnpm is not considering the option disableRelease. As documented, for pnpm it should configured like this:
  plugins: {
    'release-it-pnpm': {
      pnpm: {
        disableRelease: true,
      },
    },
  },

the code was ignoring this option.

### Linked Issues


### Additional context

I use release-it-pnpm in combination with forgejo git repository, where I observed that the configuration has not been respected. 

<!-- e.g. is there anything you'd like reviewers to focus on? -->
