### PR TITLE
fix: GitHub Release should be created when `github.release` is undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -232,7 +232,7 @@ class ReleaseItPnpmPlugin extends Plugin {
   }
 
   async release() {
-    if (this.options?.disableRelease || this.options?.pnpm?.disableRelease || !this.options?.github?.release)
+    if (this.options?.disableRelease || this.options?.pnpm?.disableRelease || this.options?.github?.release === false)
       return
 
     await this.step({


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Currently, differing from the behavior described in the docs, GitHub Releases are no longer created by default.

This is because a change was introduced in this PR that prevents release creation even if `github.release` is `undefined`:
- https://github.com/hyoban/release-it-pnpm/pull/25

Considering the expected behavior, if `github.release` is `undefined` (i.e., not set), the release process should still proceed. Therefore, `github.release` should be explicitly compared to `false`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
